### PR TITLE
[AXB-218] do not show inactive/active delegate header when there're less than 10 proposals

### DIFF
--- a/src/components/Delegates/DelegateCard/DelegateCardHeader.tsx
+++ b/src/components/Delegates/DelegateCard/DelegateCardHeader.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useApprovedProposals } from "@/hooks/useApprovedProposals";
+
 interface Props {
   participationRate?: string | null;
 }
@@ -7,6 +9,10 @@ interface Props {
 export const DelegateCardHeader = ({ participationRate }: Props) => {
   const percentParticipation = Number(participationRate) * 100;
   const numProposalsOutOfTen = Number(participationRate) * 10;
+
+  const { totalProposals } = useApprovedProposals({ pageSize: 10 });
+
+  if (!totalProposals || totalProposals < 10) return null;
 
   return Number(participationRate) > 0.5 ? (
     <ActiveHeader

--- a/src/hooks/useApprovedProposals.ts
+++ b/src/hooks/useApprovedProposals.ts
@@ -43,6 +43,7 @@ export const useApprovedProposals = ({
 
   return {
     proposals: flatData,
+    totalProposals: data?.pages[0]?.count,
     error,
     isFetching,
     fetchNextPage,


### PR DESCRIPTION
## 📝 Summary of Changes

Do not show inactive/active delegate header when there're less than 10 proposals

## 📦 Type of Change

bug

## ✅ Testing

check delegate page when there're less than 10 proposals

## 📸 Screenshots (if applicable)

| Before                        | After                       |
| ----------------------------- | --------------------------- |
| <img width="376" height="107" alt="image" src="https://github.com/user-attachments/assets/11586cfb-23e8-4bd7-8753-bca2de23f104" /> | <img width="862" height="548" alt="image" src="https://github.com/user-attachments/assets/7224f385-3b1f-4431-b70a-2b61f8d87a10" /> |

---
