### PR TITLE
Filter out duplicate delegates returned by API when sorting by random

### DIFF
--- a/src/hooks/useDelegates.ts
+++ b/src/hooks/useDelegates.ts
@@ -49,7 +49,17 @@ export const useDelegates = ({
 
   const flatData = useMemo(() => {
     const records = data?.pages.map((page) => page.delegates).flat();
-    return records?.flat();
+
+    // If sorting by random, there is a known API issue where the same delegate
+    // can get returned across multiple pages. This is a hacky workaround until we
+    // can implement a better random sorting solution that works for pagination.
+    // See https://voteagora.atlassian.net/browse/AXB-238
+    const uniqueDelegatesMap = new Map();
+    records?.forEach((delegate) => {
+      uniqueDelegatesMap.set(delegate.address, delegate);
+    });
+
+    return Array.from(uniqueDelegatesMap.values());
   }, [data]);
 
   return {


### PR DESCRIPTION
## 📝 Summary of Changes

The `ORDER BY` clause we use for randomly sorting delegates on the backend runs the risk of returning duplicates when paginating because we are using `random()`, which means the order changes between querying each page, meaning a delegate can be in a different position between queries and returned twice. 


## 📦 Type of Change

Bug

## ✅ Testing

Ensure `/delegates` page doesn't display duplicates
