### PR TITLE
[AXB-232] Update voting power on /delegates page when delegating/undelegating

### DIFF
--- a/src/app/near/VeNearDebugCards.tsx
+++ b/src/app/near/VeNearDebugCards.tsx
@@ -100,16 +100,28 @@ export default function VeNearDebugCards() {
   const [selectedVotes, setSelectedVotes] = useState<Record<number, number>>(
     {}
   );
+
+  const lockedNear = Big(accountInfo?.totalBalance.near || "0").plus(
+    accountInfo?.totalBalance.extraBalance || "0"
+  );
+
   const {
     delegateAll,
     isDelegating,
     error: delegationError,
-  } = useDelegateAll({});
+  } = useDelegateAll({
+    delegateVotingPower: lockedNear,
+    currentDelegateeAddress: accountInfo?.delegation?.delegatee,
+  });
+
   const {
     undelegate,
     isUndelegating,
     error: undelegationError,
-  } = useUndelegate({});
+  } = useUndelegate({
+    delegateVotingPower: lockedNear,
+    delegateeAddress: accountInfo?.delegation?.delegatee ?? "",
+  });
 
   const lockAllNear = useCallback(() => {
     if (accountInfo?.lockupAccountId) {

--- a/src/components/Dialogs/DelegateDialog/DelegateDialog.tsx
+++ b/src/components/Dialogs/DelegateDialog/DelegateDialog.tsx
@@ -6,6 +6,7 @@ import { useVenearAccountInfo } from "@/hooks/useVenearAccountInfo";
 import { ArrowDownIcon } from "@heroicons/react/20/solid";
 import { useCallback } from "react";
 import toast from "react-hot-toast";
+import Big from "big.js";
 
 export function DelegateDialog({
   delegateAddress,
@@ -17,11 +18,17 @@ export function DelegateDialog({
   const { signedAccountId } = useNear();
   const { data: accountInfo } = useVenearAccountInfo(signedAccountId);
 
+  const delegatableVotingPower = Big(
+    accountInfo?.totalBalance?.near || "0"
+  ).plus(accountInfo?.totalBalance?.extraBalance || "0");
+
   const { delegateAll, isDelegating, error } = useDelegateAll({
     onSuccess: () => {
       toast.success("Delegation completed!");
       closeDialog();
     },
+    delegateVotingPower: delegatableVotingPower,
+    currentDelegateeAddress: accountInfo?.delegation?.delegatee,
   });
 
   const handleDelegate = useCallback(() => {

--- a/src/components/Dialogs/UndelegateDialog/UndelegateDialog.tsx
+++ b/src/components/Dialogs/UndelegateDialog/UndelegateDialog.tsx
@@ -6,6 +6,7 @@ import { useVenearAccountInfo } from "@/hooks/useVenearAccountInfo";
 import { ArrowDownIcon } from "@heroicons/react/20/solid";
 import { useCallback } from "react";
 import toast from "react-hot-toast";
+import Big from "big.js";
 
 export function UndelegateDialog({
   delegateAddress,
@@ -16,11 +17,18 @@ export function UndelegateDialog({
 }) {
   const { signedAccountId } = useNear();
   const { data: accountInfo } = useVenearAccountInfo(signedAccountId);
+
+  const delegatableVotingPower = Big(
+    accountInfo?.totalBalance?.near || "0"
+  ).plus(accountInfo?.totalBalance?.extraBalance || "0");
+
   const { undelegate, isUndelegating, error } = useUndelegate({
     onSuccess: () => {
       toast.success("Undelegation completed!");
       closeDialog();
     },
+    delegateVotingPower: delegatableVotingPower,
+    delegateeAddress: delegateAddress,
   });
 
   const handleUndelegate = useCallback(() => {

--- a/src/hooks/__tests__/useDeployLockupAndLock.test.tsx
+++ b/src/hooks/__tests__/useDeployLockupAndLock.test.tsx
@@ -105,6 +105,8 @@ describe("useDeployLockupAndLock", () => {
       source: "onboarding" as const,
       venearStorageCost: "1000000000000000000000000",
       lockupStorageCost: "2000000000000000000000000",
+      venearAccountLockupVersion: 1,
+      venearGlobalLockupVersion: 1,
     };
 
     const result = { ...defaults, ...overrides };

--- a/src/hooks/__tests__/useUndelegate.test.tsx
+++ b/src/hooks/__tests__/useUndelegate.test.tsx
@@ -414,11 +414,11 @@ describe("useUndelegate", () => {
       const updaterFunction = mockSetQueryData.mock.calls[0][1];
       const updatedData = updaterFunction(mockDataWithNullPower);
 
-      // Check that null voting power is treated as "0" and updated correctly
+      // Check that null voting power is treated as "0" and clamped to 0 (never goes negative)
       const delegatee = updatedData.pages[0].delegates.find(
         (d: any) => d.address === "delegate-with-null.testnet"
       );
-      expect(delegatee.votingPower).toBe("-100"); // 0 - 100
+      expect(delegatee.votingPower).toBe("0"); // 0 - 100 = 0 (clamped to minimum of 0)
     });
 
     it("should not modify delegates that are not the delegatee", () => {

--- a/src/hooks/__tests__/useUndelegate.test.tsx
+++ b/src/hooks/__tests__/useUndelegate.test.tsx
@@ -1,11 +1,14 @@
 import { useWriteHOSContract } from "@/hooks/useWriteHOSContract";
 import { TESTNET_CONTRACTS } from "@/lib/contractConstants";
 import { READ_NEAR_CONTRACT_QK } from "@/hooks/useReadHOSContract";
+import { DELEGATES_QK } from "@/hooks/useDelegates";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useUndelegate } from "../useUndelegate";
+import { withNuqsTestingAdapter } from "nuqs/adapters/testing";
+import Big from "big.js";
 
 // Mock the hooks
 vi.mock("@/hooks/useWriteHOSContract", () => ({
@@ -31,11 +34,13 @@ describe("useUndelegate", () => {
   let mockMutateAsync: ReturnType<typeof vi.fn>;
   let mockOnSuccess: ReturnType<typeof vi.fn>;
   let mockInvalidateQueries: ReturnType<typeof vi.fn>;
+  let mockSetQueryData: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
 
     mockInvalidateQueries = vi.fn();
+    mockSetQueryData = vi.fn();
     queryClient = new QueryClient({
       defaultOptions: {
         queries: {
@@ -50,11 +55,18 @@ describe("useUndelegate", () => {
       },
     });
 
-    // Mock invalidateQueries
+    // Mock invalidateQueries and setQueryData
     queryClient.invalidateQueries = mockInvalidateQueries;
+    queryClient.setQueryData = mockSetQueryData;
+
+    const TestingAdapter = withNuqsTestingAdapter({
+      searchParams: {},
+    });
 
     wrapper = ({ children }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        <TestingAdapter>{children}</TestingAdapter>
+      </QueryClientProvider>
     );
 
     mockMutate = vi.fn();
@@ -86,14 +98,28 @@ describe("useUndelegate", () => {
 
   describe("Hook Initialization", () => {
     it("should initialize with correct default values", () => {
-      const { result } = renderHook(() => useUndelegate({}), { wrapper });
+      const { result } = renderHook(
+        () =>
+          useUndelegate({
+            delegateVotingPower: new Big("100"),
+            delegateeAddress: "delegate.testnet",
+          }),
+        { wrapper }
+      );
 
       expect(result.current.error).toBeNull();
       expect(result.current.isUndelegating).toBe(false);
     });
 
     it("should call useWriteHOSContract with correct parameters", () => {
-      renderHook(() => useUndelegate({}), { wrapper });
+      renderHook(
+        () =>
+          useUndelegate({
+            delegateVotingPower: new Big("100"),
+            delegateeAddress: "delegate.testnet",
+          }),
+        { wrapper }
+      );
 
       expect(mockUseWriteHOSContract).toHaveBeenCalledWith({
         contractType: "VENEAR",
@@ -111,7 +137,14 @@ describe("useUndelegate", () => {
         data: undefined,
       } as any);
 
-      const { result } = renderHook(() => useUndelegate({}), { wrapper });
+      const { result } = renderHook(
+        () =>
+          useUndelegate({
+            delegateVotingPower: new Big("100"),
+            delegateeAddress: "delegate.testnet",
+          }),
+        { wrapper }
+      );
 
       expect(result.current.error).toBe(mockError);
     });
@@ -125,7 +158,14 @@ describe("useUndelegate", () => {
         data: undefined,
       } as any);
 
-      const { result } = renderHook(() => useUndelegate({}), { wrapper });
+      const { result } = renderHook(
+        () =>
+          useUndelegate({
+            delegateVotingPower: new Big("100"),
+            delegateeAddress: "delegate.testnet",
+          }),
+        { wrapper }
+      );
 
       expect(result.current.isUndelegating).toBe(true);
     });
@@ -133,7 +173,14 @@ describe("useUndelegate", () => {
 
   describe("undelegate", () => {
     it("should call mutate with correct parameters", () => {
-      const { result } = renderHook(() => useUndelegate({}), { wrapper });
+      const { result } = renderHook(
+        () =>
+          useUndelegate({
+            delegateVotingPower: new Big("100"),
+            delegateeAddress: "delegate.testnet",
+          }),
+        { wrapper }
+      );
 
       act(() => {
         result.current.undelegate();
@@ -153,7 +200,14 @@ describe("useUndelegate", () => {
       const mockResult = { success: true };
       mockMutate.mockReturnValue(mockResult);
 
-      const { result } = renderHook(() => useUndelegate({}), { wrapper });
+      const { result } = renderHook(
+        () =>
+          useUndelegate({
+            delegateVotingPower: new Big("100"),
+            delegateeAddress: "delegate.testnet",
+          }),
+        { wrapper }
+      );
 
       const undelegateResult = result.current.undelegate();
 
@@ -163,7 +217,14 @@ describe("useUndelegate", () => {
 
   describe("Success Callback", () => {
     it("should invalidate queries on success", () => {
-      renderHook(() => useUndelegate({}), { wrapper });
+      renderHook(
+        () =>
+          useUndelegate({
+            delegateVotingPower: new Big("100"),
+            delegateeAddress: "delegate.testnet",
+          }),
+        { wrapper }
+      );
 
       // Get the onSuccess callback that was passed to useWriteHOSContract
       const onSuccessCallback =
@@ -179,9 +240,17 @@ describe("useUndelegate", () => {
     });
 
     it("should call onSuccess callback when provided", () => {
-      renderHook(() => useUndelegate({ onSuccess: mockOnSuccess }), {
-        wrapper,
-      });
+      renderHook(
+        () =>
+          useUndelegate({
+            onSuccess: mockOnSuccess,
+            delegateVotingPower: new Big("100"),
+            delegateeAddress: "delegate.testnet",
+          }),
+        {
+          wrapper,
+        }
+      );
 
       // Get the onSuccess callback that was passed to useWriteHOSContract
       const onSuccessCallback =
@@ -192,6 +261,241 @@ describe("useUndelegate", () => {
       });
 
       expect(mockOnSuccess).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Query Data Updates", () => {
+    const mockDelegatesData = {
+      pages: [
+        {
+          delegates: [
+            {
+              address: "delegate1.testnet",
+              votingPower: "1000",
+              name: "Delegate 1",
+            },
+            {
+              address: "delegate2.testnet",
+              votingPower: "2000",
+              name: "Delegate 2",
+            },
+            {
+              address: "current-delegate.testnet",
+              votingPower: "500",
+              name: "Current Delegate",
+            },
+          ],
+        },
+      ],
+      pageParams: [undefined],
+    };
+
+    beforeEach(() => {
+      // Mock the setQueryData to return the mock data when called with a function
+      mockSetQueryData.mockImplementation((queryKey, updaterFn) => {
+        if (typeof updaterFn === "function") {
+          return updaterFn(mockDelegatesData);
+        }
+        return mockDelegatesData;
+      });
+    });
+
+    it("should call setQueryData with correct query key", () => {
+      const TestingAdapter = withNuqsTestingAdapter({
+        searchParams: {
+          order_by: "voting_power",
+          filter: "active",
+          issues: "governance",
+        },
+      });
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+          <TestingAdapter>{children}</TestingAdapter>
+        </QueryClientProvider>
+      );
+
+      renderHook(
+        () =>
+          useUndelegate({
+            delegateVotingPower: new Big("100"),
+            delegateeAddress: "current-delegate.testnet",
+          }),
+        { wrapper }
+      );
+
+      // Get the onSuccess callback and trigger it
+      const onSuccessCallback =
+        mockUseWriteHOSContract.mock.calls[0]?.[0]?.onSuccess;
+
+      act(() => {
+        onSuccessCallback?.();
+      });
+
+      expect(mockSetQueryData).toHaveBeenCalledWith(
+        [DELEGATES_QK, "voting_power", "active", "governance"],
+        expect.any(Function)
+      );
+    });
+
+    it("should update voting power for delegatee (subtracting voting power)", () => {
+      renderHook(
+        () =>
+          useUndelegate({
+            delegateVotingPower: new Big("100"),
+            delegateeAddress: "current-delegate.testnet",
+          }),
+        { wrapper }
+      );
+
+      // Get the onSuccess callback and trigger it
+      const onSuccessCallback =
+        mockUseWriteHOSContract.mock.calls[0]?.[0]?.onSuccess;
+
+      act(() => {
+        onSuccessCallback?.();
+      });
+
+      // Verify setQueryData was called
+      expect(mockSetQueryData).toHaveBeenCalled();
+
+      // Get the updater function that was passed to setQueryData
+      const updaterFunction = mockSetQueryData.mock.calls[0][1];
+      const updatedData = updaterFunction(mockDelegatesData);
+
+      // Check that the delegatee's voting power was decreased
+      const delegatee = updatedData.pages[0].delegates.find(
+        (d: any) => d.address === "current-delegate.testnet"
+      );
+      expect(delegatee.votingPower).toBe("400"); // 500 - 100
+    });
+
+    it("should handle delegates with null voting power", () => {
+      const mockDataWithNullPower = {
+        pages: [
+          {
+            delegates: [
+              {
+                address: "delegate-with-null.testnet",
+                votingPower: null,
+                name: "Delegate With Null",
+              },
+            ],
+          },
+        ],
+        pageParams: [undefined],
+      };
+
+      mockSetQueryData.mockImplementation((queryKey, updaterFn) => {
+        if (typeof updaterFn === "function") {
+          return updaterFn(mockDataWithNullPower);
+        }
+        return mockDataWithNullPower;
+      });
+
+      renderHook(
+        () =>
+          useUndelegate({
+            delegateVotingPower: new Big("100"),
+            delegateeAddress: "delegate-with-null.testnet",
+          }),
+        { wrapper }
+      );
+
+      // Get the onSuccess callback and trigger it
+      const onSuccessCallback =
+        mockUseWriteHOSContract.mock.calls[0]?.[0]?.onSuccess;
+
+      act(() => {
+        onSuccessCallback?.();
+      });
+
+      // Get the updater function that was passed to setQueryData
+      const updaterFunction = mockSetQueryData.mock.calls[0][1];
+      const updatedData = updaterFunction(mockDataWithNullPower);
+
+      // Check that null voting power is treated as "0" and updated correctly
+      const delegatee = updatedData.pages[0].delegates.find(
+        (d: any) => d.address === "delegate-with-null.testnet"
+      );
+      expect(delegatee.votingPower).toBe("-100"); // 0 - 100
+    });
+
+    it("should not modify delegates that are not the delegatee", () => {
+      renderHook(
+        () =>
+          useUndelegate({
+            delegateVotingPower: new Big("100"),
+            delegateeAddress: "current-delegate.testnet",
+          }),
+        { wrapper }
+      );
+
+      // Get the onSuccess callback and trigger it
+      const onSuccessCallback =
+        mockUseWriteHOSContract.mock.calls[0]?.[0]?.onSuccess;
+
+      act(() => {
+        onSuccessCallback?.();
+      });
+
+      // Get the updater function that was passed to setQueryData
+      const updaterFunction = mockSetQueryData.mock.calls[0][1];
+      const updatedData = updaterFunction(mockDelegatesData);
+
+      // Check that other delegates remain unchanged
+      const unchangedDelegate1 = updatedData.pages[0].delegates.find(
+        (d: any) => d.address === "delegate1.testnet"
+      );
+      const unchangedDelegate2 = updatedData.pages[0].delegates.find(
+        (d: any) => d.address === "delegate2.testnet"
+      );
+      expect(unchangedDelegate1.votingPower).toBe("1000"); // Unchanged
+      expect(unchangedDelegate2.votingPower).toBe("2000"); // Unchanged
+    });
+
+    it("should call invalidateQueries for delegates after setQueryData", () => {
+      const TestingAdapter = withNuqsTestingAdapter({
+        searchParams: {
+          order_by: "voting_power",
+          filter: "active",
+          issues: "governance",
+        },
+      });
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+          <TestingAdapter>{children}</TestingAdapter>
+        </QueryClientProvider>
+      );
+
+      renderHook(
+        () =>
+          useUndelegate({
+            delegateVotingPower: new Big("100"),
+            delegateeAddress: "current-delegate.testnet",
+          }),
+        { wrapper }
+      );
+
+      // Get the onSuccess callback and trigger it
+      const onSuccessCallback =
+        mockUseWriteHOSContract.mock.calls[0]?.[0]?.onSuccess;
+
+      act(() => {
+        onSuccessCallback?.();
+      });
+
+      // Verify that both setQueryData and invalidateQueries were called for delegates
+      expect(mockSetQueryData).toHaveBeenCalledWith(
+        [DELEGATES_QK, "voting_power", "active", "governance"],
+        expect.any(Function)
+      );
+
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({
+        queryKey: [DELEGATES_QK, "voting_power", "active", "governance"],
+        refetchType: "none",
+      });
     });
   });
 });

--- a/src/hooks/useDelegateAll.ts
+++ b/src/hooks/useDelegateAll.ts
@@ -33,6 +33,10 @@ export function useDelegateAll({
       queryKey: [READ_NEAR_CONTRACT_QK, TESTNET_CONTRACTS.VENEAR_CONTRACT_ID],
     });
 
+    // We mutate the client cache directly here instead of invalidating the query since
+    // this would trigger a re-fetch of the delegates, which by default is sorting the delegates
+    // in random order. This would cause the ordering of the delegates to change which
+    // would be jarring to the user.
     queryClient.setQueryData(
       [DELEGATES_QK, orderByParam, filterParam, issuesParam],
       (oldData: InfiniteData<GetDelegatesResponse>) => {

--- a/src/hooks/useDelegateAll.ts
+++ b/src/hooks/useDelegateAll.ts
@@ -72,6 +72,11 @@ export function useDelegateAll({
       }
     );
 
+    queryClient.invalidateQueries({
+      queryKey: [DELEGATES_QK, orderByParam, filterParam, issuesParam],
+      refetchType: "none",
+    });
+
     onSuccess?.();
   }, [
     queryClient,

--- a/src/hooks/useDelegateAll.ts
+++ b/src/hooks/useDelegateAll.ts
@@ -1,22 +1,87 @@
-import { useWriteHOSContract } from "./useWriteHOSContract";
 import { TESTNET_CONTRACTS } from "@/lib/contractConstants";
-import { useCallback } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { InfiniteData, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useRef } from "react";
+import { DELEGATES_QK } from "./useDelegates";
 import { READ_NEAR_CONTRACT_QK } from "./useReadHOSContract";
+import { useWriteHOSContract } from "./useWriteHOSContract";
+import { useQueryState } from "nuqs";
+import Big from "big.js";
+import { GetDelegatesResponse } from "@/lib/api/delegates/types";
 
 type Props = {
   onSuccess?: () => void;
+  delegateVotingPower: Big;
+  currentDelegateeAddress?: string;
 };
 
-export function useDelegateAll({ onSuccess }: Props) {
+export function useDelegateAll({
+  onSuccess,
+  delegateVotingPower,
+  currentDelegateeAddress,
+}: Props) {
   const queryClient = useQueryClient();
+  const targetDelegateeAddressRef = useRef<string>();
+  const [orderByParam] = useQueryState("order_by");
+  const [filterParam] = useQueryState("filter");
+  const [issuesParam] = useQueryState("issues", {
+    defaultValue: "",
+    clearOnDefault: true,
+  });
 
   const onDelegateSuccess = useCallback(() => {
     queryClient.invalidateQueries({
       queryKey: [READ_NEAR_CONTRACT_QK, TESTNET_CONTRACTS.VENEAR_CONTRACT_ID],
     });
+
+    queryClient.setQueryData(
+      [DELEGATES_QK, orderByParam, filterParam, issuesParam],
+      (oldData: InfiniteData<GetDelegatesResponse>) => {
+        const updatedPages = oldData?.pages.map((page) => {
+          return {
+            ...page,
+            delegates: page.delegates.map((delegate) => {
+              const delegateeVotingPower = Big(delegate.votingPower ?? "0");
+
+              if (delegate.address === targetDelegateeAddressRef.current) {
+                return {
+                  ...delegate,
+                  votingPower: delegateeVotingPower
+                    .plus(delegateVotingPower)
+                    .toFixed(),
+                };
+              }
+
+              if (delegate.address === currentDelegateeAddress) {
+                return {
+                  ...delegate,
+                  votingPower: delegateeVotingPower
+                    .minus(delegateVotingPower)
+                    .toFixed(),
+                };
+              }
+
+              return delegate;
+            }),
+          };
+        });
+
+        return {
+          ...oldData,
+          pages: updatedPages,
+        };
+      }
+    );
+
     onSuccess?.();
-  }, [queryClient, onSuccess]);
+  }, [
+    queryClient,
+    orderByParam,
+    filterParam,
+    issuesParam,
+    onSuccess,
+    currentDelegateeAddress,
+    delegateVotingPower,
+  ]);
 
   const { mutate, isPending, error } = useWriteHOSContract({
     contractType: "VENEAR",
@@ -25,6 +90,7 @@ export function useDelegateAll({ onSuccess }: Props) {
 
   const delegateAll = useCallback(
     (receiverId: string) => {
+      targetDelegateeAddressRef.current = receiverId;
       return mutate({
         contractId: TESTNET_CONTRACTS.VENEAR_CONTRACT_ID,
         methodCalls: [

--- a/src/hooks/useDelegateAll.ts
+++ b/src/hooks/useDelegateAll.ts
@@ -52,11 +52,14 @@ export function useDelegateAll({
               }
 
               if (delegate.address === currentDelegateeAddress) {
+                const newDelegateeVotingPower =
+                  delegateeVotingPower.minus(delegateVotingPower);
+
                 return {
                   ...delegate,
-                  votingPower: delegateeVotingPower
-                    .minus(delegateVotingPower)
-                    .toFixed(),
+                  votingPower: newDelegateeVotingPower.lt(0)
+                    ? "0"
+                    : newDelegateeVotingPower.toFixed(),
                 };
               }
 

--- a/src/hooks/useDelegates.ts
+++ b/src/hooks/useDelegates.ts
@@ -4,7 +4,7 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useQueryState } from "nuqs";
 
-const DELEGATES_QK = `${Endpoint.Delegates}`;
+export const DELEGATES_QK = `${Endpoint.Delegates}`;
 
 const sortingSeed = Math.random();
 
@@ -31,7 +31,7 @@ export const useDelegates = ({
     isFetchingNextPage,
     status,
   } = useInfiniteQuery({
-    queryKey: [`${DELEGATES_QK}-${orderBy}-${filter}-${issuesParam}`],
+    queryKey: [DELEGATES_QK, orderBy, filter, issuesParam],
     queryFn: ({ pageParam = 1 }) => {
       return fetchDelegates(
         pageSize,

--- a/src/hooks/useUndelegate.ts
+++ b/src/hooks/useUndelegate.ts
@@ -1,22 +1,82 @@
 import { useWriteHOSContract } from "./useWriteHOSContract";
 import { TESTNET_CONTRACTS } from "@/lib/contractConstants";
 import { useCallback } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { InfiniteData, useQueryClient } from "@tanstack/react-query";
 import { READ_NEAR_CONTRACT_QK } from "./useReadHOSContract";
+import { DELEGATES_QK } from "./useDelegates";
+import { GetDelegatesResponse } from "@/lib/api/delegates/types";
+import { useQueryState } from "nuqs";
+import Big from "big.js";
 
 type Props = {
   onSuccess?: () => void;
+  delegateVotingPower: Big;
+  delegateeAddress: string;
 };
 
-export function useUndelegate({ onSuccess }: Props) {
+export function useUndelegate({
+  onSuccess,
+  delegateVotingPower,
+  delegateeAddress,
+}: Props) {
   const queryClient = useQueryClient();
+  const [orderByParam] = useQueryState("order_by");
+  const [filterParam] = useQueryState("filter");
+  const [issuesParam] = useQueryState("issues", {
+    defaultValue: "",
+    clearOnDefault: true,
+  });
 
   const onUndelegateSuccess = useCallback(() => {
     queryClient.invalidateQueries({
       queryKey: [READ_NEAR_CONTRACT_QK, TESTNET_CONTRACTS.VENEAR_CONTRACT_ID],
     });
+
+    queryClient.setQueryData(
+      [DELEGATES_QK, orderByParam, filterParam, issuesParam],
+      (oldData: InfiniteData<GetDelegatesResponse>) => {
+        const updatedPages = oldData?.pages.map((page) => {
+          return {
+            ...page,
+            delegates: page.delegates.map((delegate) => {
+              const delegateeVotingPower = Big(delegate.votingPower ?? "0");
+
+              if (delegate.address === delegateeAddress) {
+                return {
+                  ...delegate,
+                  votingPower: delegateeVotingPower
+                    .minus(delegateVotingPower)
+                    .toFixed(),
+                };
+              }
+
+              return delegate;
+            }),
+          };
+        });
+
+        return {
+          ...oldData,
+          pages: updatedPages,
+        };
+      }
+    );
+
+    queryClient.invalidateQueries({
+      queryKey: [DELEGATES_QK, orderByParam, filterParam, issuesParam],
+      refetchType: "none",
+    });
+
     onSuccess?.();
-  }, [queryClient, onSuccess]);
+  }, [
+    queryClient,
+    orderByParam,
+    filterParam,
+    issuesParam,
+    onSuccess,
+    delegateeAddress,
+    delegateVotingPower,
+  ]);
 
   const { mutate, isPending, error } = useWriteHOSContract({
     contractType: "VENEAR",

--- a/src/hooks/useUndelegate.ts
+++ b/src/hooks/useUndelegate.ts
@@ -32,6 +32,10 @@ export function useUndelegate({
       queryKey: [READ_NEAR_CONTRACT_QK, TESTNET_CONTRACTS.VENEAR_CONTRACT_ID],
     });
 
+    // We mutate the client cache directly here instead of invalidating the query since
+    // this would trigger a re-fetch of the delegates, which by default is sorting the delegates
+    // in random order. This would cause the ordering of the delegates to change which
+    // would be jarring to the user.
     queryClient.setQueryData(
       [DELEGATES_QK, orderByParam, filterParam, issuesParam],
       (oldData: InfiniteData<GetDelegatesResponse>) => {

--- a/src/hooks/useUndelegate.ts
+++ b/src/hooks/useUndelegate.ts
@@ -42,11 +42,14 @@ export function useUndelegate({
               const delegateeVotingPower = Big(delegate.votingPower ?? "0");
 
               if (delegate.address === delegateeAddress) {
+                const newDelegateeVotingPower =
+                  delegateeVotingPower.minus(delegateVotingPower);
+
                 return {
                   ...delegate,
-                  votingPower: delegateeVotingPower
-                    .minus(delegateVotingPower)
-                    .toFixed(),
+                  votingPower: newDelegateeVotingPower.lt(0)
+                    ? "0"
+                    : newDelegateeVotingPower.toFixed(),
                 };
               }
 


### PR DESCRIPTION
…ation

## 📝 Summary of Changes

Previously when you delegate/undelegate from the `/delegates` page, the voting power of the delegate and the old delegatee (if already delegating) would not updated. This was due to a stale cache.

At first glance, I thought we could just refetch the delegates upon successful delegation/undelegation to get the updated voting power. However, given that the sort order is random by default and changes on every query, this would cause the order of the delegates to change which might be jarring to the user.

The approach I took in the PR was to manually update the cache with the new voting power, which requires a bit of math / knowledge of how the delegation works - I'm not a huge fan of doing this kind of client side logic and would rather have the backend be the source of truth but not sure I see another way around it.

**Some alternative strategies considered:**

- When they press "Delegate", first take them to the delegate profile page and then launch the dialog (avoids them seeing the shifted order after delegating but unclear if this is any less jarring of a UX)
- Default the sort order to something other than random (would still be an issue if they switched to random)
- Do nothing and allow the order to change after delegation


## 📦 Type of Change

Bug

## ✅ Testing

- Unit tests
- Manual testing

---
