### PR TITLE
Misc locking flow fixes

### DIFF
--- a/src/components/Dialogs/LockProvider.tsx
+++ b/src/components/Dialogs/LockProvider.tsx
@@ -535,8 +535,6 @@ export const LockProvider = ({
     venearAccountInfo,
   ]);
 
-  console.log(`requiredTransactions=${requiredTransactions}`);
-
   const getAmountToLock = useCallback(async () => {
     // Lock all when onboarding
     if (source === "onboarding") {


### PR DESCRIPTION
## 📝 Summary of Changes

Fixes the following issues with the locking flow:
- If the user's wallet has less than the minimum deposit amount and they press the max button, the UI doesn't currently show an error but it should.  
- If the user wants to lock exactly the minimum deposit amount (2.1 NEAR on dev), they are currently prompted with a transfer transaction for 0 NEAR (the transfer amount is the desired amount to lock minus the minimum deposit amount, which are equal in this case). In this case, we should skip the transfer transaction as a transfer for 0 NEAR results in a transaction error.

## 📦 Type of Change

- Bug

## ✅ Testing

- Manually

## 📸 Screenshots (if applicable)

| Before                        | After                       |
| ----------------------------- | --------------------------- |
| ![before](link-to-before.png) | ![after](link-to-after.png) |

---
